### PR TITLE
[Fix #8] copy array so it isn't modified in place during standardization

### DIFF
--- a/python-package/pycasso/core.py
+++ b/python-package/pycasso/core.py
@@ -388,8 +388,8 @@ class Solver:
     if lambdidx is None:
       lambdidx = self.nlambda - 1
 
-    _beta = self.result['beta'][lambdidx,]
-    _intercept = self.result['intercept'][lambdidx]
+    _beta = np.copy(self.result['beta'][lambdidx,])
+    _intercept = np.copy(self.result['intercept'][lambdidx])
     if self.standardize:
       if self.family == 'gaussian':
         _intercept += self.y_mean


### PR DESCRIPTION
Fix for issue #8.

If standardize=True and newdata is not None, then Lines 400 and 401 will modify `_beta` in place.

This caused that particular beta to change every time you run `predict`.  This fixes it by creating a copy of `_beta` to use in the predictions.

