### PR TITLE
Fix scikit-learn and compiler warnings

### DIFF
--- a/profiling/benchmark.py
+++ b/profiling/benchmark.py
@@ -119,7 +119,7 @@ def test_lognet(n, p, c, nlambda=100):
                            picasso.lambdas[idx])
 
   time0 = time.time()
-  clf = linear_model.LogisticRegression(penalty='l1', tol=1e-6, warm_start=True)
+  clf = linear_model.LogisticRegression(penalty='l1', tol=1e-6, solver='liblinear')
   coefs_ = []
   intcpt_ = []
   for lamb in picasso.lambdas:

--- a/src/solver/actgd.cpp
+++ b/src/solver/actgd.cpp
@@ -10,7 +10,7 @@ ActGDSolver::ActGDSolver(ObjFunction *obj, PicassoSolverParams param)
 }
 
 void ActGDSolver::solve() {
-  unsigned int d = m_obj->get_dim();
+  int d = m_obj->get_dim();
 
   const std::vector<double> &lambdas = m_param.get_lambda_path();
   itercnt_path.resize(lambdas.size(), 0);
@@ -38,7 +38,7 @@ void ActGDSolver::solve() {
 
   int flag1 = 0;
   int flag2 = 1;
-  for (int i = 0; i < lambdas.size(); i++) {
+  for (std::vector<double>::size_type i = 0; i < lambdas.size(); i++) {
     // m_obj->update_auxiliary();
     regfunc->set_param(lambdas[i], m_param.gamma);
 
@@ -117,7 +117,7 @@ void ActGDSolver::solve() {
         loopcnt_level_1 += 1;
 
         bool terminate_loop_level_1 = true;
-        for (int j = 0; j < actset_idx.size(); j++) {
+        for (std::vector<int>::size_type j = 0; j < actset_idx.size(); j++) {
           int idx = actset_idx[j];
           double beta_old = m_obj->get_model_coef(idx);
 

--- a/src/solver/actnewton.cpp
+++ b/src/solver/actnewton.cpp
@@ -44,7 +44,7 @@ void ActNewtonSolver::solve() {
 
   std::vector<double> stage_lambdas(d, 0);
   RegFunction *regfunc = new RegL1();
-  for (int i = 0; i < lambdas.size(); i++) {
+  for (std::vector<double>::size_type i = 0; i < lambdas.size(); i++) {
     // Rprintf("lambda[%d]:%f\n", i, lambdas[i]);
     // start with the previous solution on the master path
     m_obj->set_model_param(model_master);
@@ -70,7 +70,7 @@ void ActNewtonSolver::solve() {
 
     m_obj->update_auxiliary();
     // loop level 0: multistage convex relaxation
-    int loopcnt_level_0 = 0;
+    unsigned int loopcnt_level_0 = 0;
     int idx;
     double old_beta, old_intcpt, updated_coord, beta;
     while (loopcnt_level_0 < m_param.num_relaxation_round) {
@@ -103,7 +103,7 @@ void ActNewtonSolver::solve() {
           loopcnt_level_2++;
           terminate_loop_level_2 = true;
 
-          for (int k = 0; k < actset_idx.size(); k++) {
+          for (std::vector<int>::size_type k = 0; k < actset_idx.size(); k++) {
             idx = actset_idx[k];
 
             old_beta = m_obj->get_model_coef(idx);
@@ -130,7 +130,7 @@ void ActNewtonSolver::solve() {
 
         terminate_loop_level_1 = true;
         // check stopping criterion 1: fvalue change
-        for (int k = 0; k < actset_idx.size(); ++k) {
+        for (std::vector<int>::size_type k = 0; k < actset_idx.size(); ++k) {
           idx = actset_idx[k];
           if (m_obj->get_local_change(old_coef[idx], idx) > dev_thr)
             terminate_loop_level_1 = false;


### PR DESCRIPTION
Running benchmark.py with scikit-learn 0.20 produces numerous warning messages:

```
FutureWarning: Default solver will be changed to 'lbfgs' in 0.22.
Specify a solver to silence this warning.
```
L-BFGS doesn't support L1 penalties, which may break the benchmark soon. Explicitly setting the solver to 'liblinear', the current default, is a simple fix. Additionally, warm starts are not used by 'liblinear' according to [documentation](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html), and can be removed.

A few compiler warnings related to signed / unsigned integer comparisons are silenced along the way. Many thanks!