### PR TITLE
Fix intercept bug in actgd and size_act dimension in Python

### DIFF
--- a/python-package/pycasso/core.py
+++ b/python-package/pycasso/core.py
@@ -232,7 +232,7 @@ class Solver:
         'beta': np.zeros((self.nlambda, self.num_feature), dtype='double'),
         'intercept': np.zeros(self.nlambda, dtype='double'),
         'ite_lamb': np.zeros(self.nlambda, dtype='int32'),
-        'size_act': np.zeros((self.nlambda, self.num_feature), dtype='int32'),
+        'size_act': np.zeros(self.nlambda, dtype='int32'),
         'df': np.zeros(self.nlambda, dtype='int32'),
         'train_time': np.zeros(self.nlambda, dtype='double'),
         'num_fit': np.zeros(1, dtype='int32'),
@@ -280,7 +280,7 @@ class Solver:
         self.result['beta'] = self.result['beta'][:nfit, :]
         self.result['intercept'] = self.result['intercept'][:nfit]
         self.result['ite_lamb'] = self.result['ite_lamb'][:nfit]
-        self.result['size_act'] = self.result['size_act'][:nfit, :]
+        self.result['size_act'] = self.result['size_act'][:nfit]
         self.result['train_time'] = self.result['train_time'][:nfit]
         self.nlambda = nfit
         self.lambdas = self.lambdas[:nfit]

--- a/src/solver/actgd.cpp
+++ b/src/solver/actgd.cpp
@@ -113,7 +113,9 @@ void ActGDSolver::solve() {
       }
     }
 
-    m_obj->intercept_update();
+    if (m_param.include_intercept) {
+      m_obj->intercept_update();
+    }
 
     solution_path.push_back(m_obj->get_model_param_ref());
     runtime_path[i] = 0.0;


### PR DESCRIPTION
## Summary

- **Fix intercept unconditionally updated in `actgd.cpp`** (fixes #23, fixes #25): `intercept_update()` is now guarded by `m_param.include_intercept`, consistent with `actnewton.cpp`. Without this fix, the intercept is always updated even when `useintercept=False`.
- **Fix `size_act` dimension mismatch in `core.py`** (fixes #23): changed allocation from `(nlambda, d)` to `(nlambda,)` and fixed truncation indexing. The C API writes one `int` per lambda, not a `(d,)` array.

## Test plan

- [x] Gaussian lasso with `useintercept=False` correctly returns intercept=0
- [x] Gaussian lasso with `useintercept=True` recovers correct intercept
- [x] Logistic/Poisson regression with L1/SCAD/MCP all produce valid results
- [x] `size_act` shape is `(num_fit,)` not `(num_fit, d)`