### PR TITLE
Add placeholder CircleCI config to silence stale status check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+# CircleCI is no longer used. CI has moved to GitHub Actions (.github/workflows/ci.yml).
+# This minimal config silences the "no configuration found" status check
+# until the CircleCI integration is removed from the repository.
+version: 2.1
+jobs:
+  noop:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - run: echo "CI has moved to GitHub Actions."
+workflows:
+  placeholder:
+    jobs:
+      - noop


### PR DESCRIPTION
CI 已迁移到 GitHub Actions (`.github/workflows/ci.yml`)。

由于 CircleCI 集成仍然挂在 repo 上，每次 push 都会报 "no configuration found" 警告。这个最小化的 `.circleci/config.yml` 让该检查正常通过，直到 repo owner 移除 CircleCI 集成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)